### PR TITLE
Changed local version identifier to post-notation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}+0.py37fix
+  version: {{ version }}.post0
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
@@ -14,7 +14,7 @@ source:
     - python37-PEP479-fix.patch
 
 build:
-  number: 1001
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:


### PR DESCRIPTION
Wasn't aware of https://github.com/conda/conda/issues/4962 .
Local version identifiers don't work, so I'll re-release this as "0.2.0.post0", so `conda` will automatically pull the newer, fixed version.

Closes #5 .